### PR TITLE
Fix Y axis gesture filtering by batching events per SYN_REPORT

### DIFF
--- a/src/states.rs
+++ b/src/states.rs
@@ -147,12 +147,7 @@ impl Swiping {
         self.pending_dy += dy;
     }
 
-    pub fn flush(
-        &mut self,
-        sink: &mut VirtualDevice,
-        x_mult: f32,
-        y_mult: f32,
-    ) -> Result<()> {
+    pub fn flush(&mut self, sink: &mut VirtualDevice, x_mult: f32, y_mult: f32) -> Result<()> {
         if self.pending_dx == 0 && self.pending_dy == 0 {
             return Ok(());
         }

--- a/src/states.rs
+++ b/src/states.rs
@@ -118,6 +118,8 @@ impl Normal {
             trigger,
             x: 0,
             y: 0,
+            pending_dx: 0,
+            pending_dy: 0,
         })
     }
 }
@@ -129,6 +131,8 @@ pub struct Swiping {
     pub fingers: Fingers,
     pub x: i32,
     pub y: i32,
+    pending_dx: i32,
+    pending_dy: i32,
 }
 
 impl From<Swiping> for State {
@@ -138,29 +142,25 @@ impl From<Swiping> for State {
 }
 
 impl Swiping {
-    pub fn update(
+    pub fn accumulate(&mut self, dx: i32, dy: i32) {
+        self.pending_dx += dx;
+        self.pending_dy += dy;
+    }
+
+    pub fn flush(
         &mut self,
         sink: &mut VirtualDevice,
-        dx: i32,
-        dy: i32,
         x_mult: f32,
         y_mult: f32,
     ) -> Result<()> {
-        self.x += dx;
-        self.y += dy;
+        if self.pending_dx == 0 && self.pending_dy == 0 {
+            return Ok(());
+        }
 
-        /*
-        E: 0.020080 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
-        E: 0.020080 0003 0035 0686	# EV_ABS / ABS_MT_POSITION_X    686
-        E: 0.020080 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
-        E: 0.020080 0003 0035 0878	# EV_ABS / ABS_MT_POSITION_X    878
-        E: 0.020080 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
-        E: 0.020080 0003 0035 0675	# EV_ABS / ABS_MT_POSITION_X    675
-        E: 0.020080 0003 0036 0442	# EV_ABS / ABS_MT_POSITION_Y    442
-        E: 0.020080 0003 0000 0686	# EV_ABS / ABS_X                686
-        E: 0.020080 0004 0005 21000	# EV_MSC / MSC_TIMESTAMP        21000
-        E: 0.020080 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
-        */
+        self.x += self.pending_dx;
+        self.y += self.pending_dy;
+        self.pending_dx = 0;
+        self.pending_dy = 0;
 
         #[allow(clippy::cast_precision_loss)]
         #[allow(clippy::cast_possible_truncation)]

--- a/src/swipe.rs
+++ b/src/swipe.rs
@@ -402,15 +402,17 @@ fn on_input_event(
         }
         State::Swiping(mut swiping) => match input.kind() {
             InputEventKind::RelAxis(RelativeAxisType::REL_X) => {
-                swiping
-                    .update(sink, input.value(), 0, x_mult, y_mult)
-                    .with_context(|| "failed to update swipe position")?;
+                swiping.accumulate(input.value(), 0);
                 swiping.into()
             }
             InputEventKind::RelAxis(RelativeAxisType::REL_Y) => {
+                swiping.accumulate(0, input.value());
+                swiping.into()
+            }
+            InputEventKind::Synchronization(evdev::Synchronization::SYN_REPORT) => {
                 swiping
-                    .update(sink, 0, input.value(), x_mult, y_mult)
-                    .with_context(|| "failed to update swipe position")?;
+                    .flush(sink, x_mult, y_mult)
+                    .with_context(|| "failed to flush swipe position")?;
                 swiping.into()
             }
             InputEventKind::Key(key) if key == swiping.trigger && input.value() == 0 => {


### PR DESCRIPTION
The issue was that REL_X and REL_Y events from the mouse were processed separately, each triggering a full trackpad frame (with SYN_REPORT). When the mouse moved diagonally, libinput would see:
Frame 1: pure horizontal movement (X changed, Y didn't)
Frame 2: only vertical movement (Y changed)
This biased the gesture direction detection toward horizontal, making vertical gestures feel heavily filtered/dampened.

The fix accumulates REL_X and REL_Y deltas and only emits a single trackpad frame on SYN_REPORT from the mouse — exactly how a real trackpad works, where all coordinate changes arrive in one frame.

This fixes issue that I reported https://github.com/aecsocket/fukomaster/issues/4